### PR TITLE
Corrected company name for RHT tokens

### DIFF
--- a/tokenList.json
+++ b/tokenList.json
@@ -99,7 +99,7 @@
   },
   "RHT": {
     "symbol": "RHT",
-    "companyName": "Redeemable HashPuppy Token",
+    "companyName": "Splyse",
     "type": "NEP5",
     "networks": {
       "1": {


### PR DESCRIPTION
Updated the tokenList.json file with the company name for our token, RHT.