### PR TITLE
remove 0x prefix from FLM hash

### DIFF
--- a/tokenList.json
+++ b/tokenList.json
@@ -270,7 +270,7 @@
     "networks": {
       "1": {
         "name": "Flamingo Finance",
-        "hash": "0x4d9eab13620fe3569ba3b0e56e2877739e4145e3",
+        "hash": "4d9eab13620fe3569ba3b0e56e2877739e4145e3",
         "decimals": 8,
         "totalSupply": 100000000
       }


### PR DESCRIPTION
The low-level RPC invokescript code to load token symbol/decimals info in Neon Wallet/neon-js doesn't like 0x prefixes on scripthashes, and Neon fails silently and stops processing any additional token in the list if it encounters one. This leads to the condition where the token/asset balances panels will show the "retry or select a different node" message even though no network or javascript errors appear in the console.